### PR TITLE
Solves error w/ recording while saving and adds progbar

### DIFF
--- a/recordTrimEdit.py
+++ b/recordTrimEdit.py
@@ -13,6 +13,8 @@ from pygame._sdl2 import (
 )
 import pygame_widgets
 from pygame_widgets.dropdown import Dropdown
+from tqdm import tqdm # Progress bar
+from copy import deepcopy
 
 # Default parameters
 config_filename = "config.json"
@@ -308,8 +310,12 @@ while running:
     pygame_widgets.update(events)
     pg.display.flip()
 
+print('Uniting all snippets of audio')
 audio_full = np.zeros((0))
-for chunk in sound_chunks:
+recorded_sound_chunks = deepcopy(sound_chunks)
+for chunk in tqdm(recorded_sound_chunks):
     audio_full = np.append(audio_full,np.frombuffer(chunk, dtype=np.int16))
+
+print('Saving your .wav file')
 
 saveWav(destination,audio_full)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pygame==2.5.2
 pygame-widgets==1.1.5
 scipy==1.12.0
 soundfile==0.12.1
+tqdm==4.66.2


### PR DESCRIPTION
After recording a file, when saving, everything froze, without any output and without giving any hints on what might be.

After some debugging, I found out that the sound_chunks variable (list) kept appending while saving.
This hit a point that the sound chunks that were appending were being added faster that the ones being united to make the full audio (or at least very close to it.)
This created a seemingly never-ending creation of the full audio that never saved.

To solve this, before saving, a copy of the sound_chunks variable is created.
This copy is the one that is saved, so no further data enters that variable.
There could be a solution to make pygame stop recording audio, but as I am not familiar with that library, I abstained from changing anything.
This solution is a simple fix that might solve it, but you might want to solve everything within pygame.

To aid debugging (and even user experience) I added prints and a progress bar when saving!